### PR TITLE
Add ability top level listener to list of structures.

### DIFF
--- a/NestLib/build.gradle
+++ b/NestLib/build.gradle
@@ -3,15 +3,15 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.+'
+        classpath 'com.android.tools.build:gradle:1.0.1+'
     }
 }
 
 apply plugin: 'android-library'
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion "19.1.0"
+    compileSdkVersion 21
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 14
@@ -21,7 +21,7 @@ android {
     }
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
         }
     }
 

--- a/NestLib/src/main/java/com/nestapi/lib/API/Listener.java
+++ b/NestLib/src/main/java/com/nestapi/lib/API/Listener.java
@@ -10,6 +10,8 @@
  */
 package com.nestapi.lib.API;
 
+import java.util.ArrayList;
+
 /**
  * This class is used to build a collection of data listeners for updates
  * to user data (devices and structure details).
@@ -17,11 +19,13 @@ package com.nestapi.lib.API;
 public final class Listener {
     private final ThermostatListener mThermostatListener;
     private final StructureListener mStructureListener;
+    private final StructuresListener mStructuresListener;
     private final SmokeCOAlarmListener mSmokeCOAlarmListener;
 
     private Listener(Builder builder) {
         mThermostatListener = builder.mThermostatListener;
         mStructureListener = builder.mStructureListener;
+        mStructuresListener = builder.mStructuresListener;
         mSmokeCOAlarmListener = builder.mSmokeCOAlarmListener;
     }
 
@@ -29,6 +33,9 @@ public final class Listener {
         return mThermostatListener;
     }
 
+    StructuresListener getStructuresListener() {
+        return mStructuresListener;
+    }
     StructureListener getStructureListener() {
         return mStructureListener;
     }
@@ -40,6 +47,7 @@ public final class Listener {
     public static class Builder {
         private ThermostatListener mThermostatListener = null;
         private StructureListener mStructureListener = null;
+        private StructuresListener mStructuresListener = null;
         private SmokeCOAlarmListener mSmokeCOAlarmListener = null;
 
         public Builder setThermostatListener(ThermostatListener listener) {
@@ -49,6 +57,11 @@ public final class Listener {
 
         public Builder setStructureListener(StructureListener listener) {
             mStructureListener = listener;
+            return this;
+        }
+
+        public Builder setStructuresListener(StructuresListener listener) {
+            mStructuresListener = listener;
             return this;
         }
 
@@ -78,6 +91,15 @@ public final class Listener {
          *                  to be non-null)
          */
         void onStructureUpdated(Structure structure);
+    }
+
+    public interface StructuresListener {
+        /**
+         * Called when updated data is retrieved for a user's structure.
+         * @param structures the new data for the structure (guaranteed
+         *                  to be non-null)
+         */
+        void onStructuresUpdated(ArrayList<Structure> structures);
     }
 
     public interface SmokeCOAlarmListener {

--- a/NestLib/src/main/java/com/nestapi/lib/API/NestAPI.java
+++ b/NestLib/src/main/java/com/nestapi/lib/API/NestAPI.java
@@ -320,9 +320,9 @@ public final class NestAPI implements ValueEventListener {
 
     @SuppressWarnings("unchecked")
     private static void updateStructures(Map<String, Object> structures, List<Listener> listeners) {
+        ArrayList<Structure> structuresList = new ArrayList<>();
         for (Map.Entry<String, Object> entry : structures.entrySet()) {
-            final Map<String, Object> value = (Map<String, Object>) entry.getValue();
-            final Structure structure = new Structure.Builder().fromMap(value);
+            Structure structure = new Structure.Builder().fromMap((Map<String, Object>) entry.getValue());
 
             if (structure != null) {
                 for (Listener listener : listeners) {
@@ -330,6 +330,13 @@ public final class NestAPI implements ValueEventListener {
                         listener.getStructureListener().onStructureUpdated(structure);
                     }
                 }
+                structuresList.add(structure);
+            }
+        }
+
+        for (Listener listener : listeners) {
+            if (listener.getStructuresListener() != null) {
+                listener.getStructuresListener().onStructuresUpdated(structuresList);
             }
         }
     }


### PR DESCRIPTION
Before this addition, the deletion of a structure was impossible to detect. A deletion event triggered the onStructureUpdated callback with the deleted structure, but no data signifying the update was caused by a deletion. This commit allows you to listen to changes to the list of structures. This will return a list of all active structures, allowing you to detect deletions, as well as additions.